### PR TITLE
Manually calculate prescaler and overflow for STM32 update timer (#69)

### DIFF
--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -520,7 +520,13 @@ static void startAudioStandard() {
   tcConfigure(AUDIO_RATE);
 #elif IS_STM32()
   audio_update_timer.pause();
-  audio_update_timer.setPeriod(1000000UL / AUDIO_RATE);
+  //audio_update_timer.setPeriod(1000000UL / AUDIO_RATE);
+  // Manually calculate prescaler and overflow instead of using setPeriod, to avoid rounding errors
+  uint32_t period_cyc = F_CPU / AUDIO_RATE;
+  uint16_t prescaler = (uint16_t)(period_cyc / 65535 + 1);
+  uint16_t overflow = (uint16_t)((period_cyc + (prescaler / 2)) / prescaler);
+  audio_update_timer.setPrescaleFactor(prescaler);
+  audio_update_timer.setOverflow(overflow);
   audio_update_timer.setChannel1Mode(TIMER_OUTPUT_COMPARE);
   audio_update_timer.setCompare(TIMER_CH1,
                                 1); // Interrupt 1 count after each update


### PR DESCRIPTION
* Manually calculate prescaler and overflow instead of using setPeriod, to avoid rounding errors